### PR TITLE
feat: expose section inertia values

### DIFF
--- a/docs/fin-bending-core.js
+++ b/docs/fin-bending-core.js
@@ -154,6 +154,29 @@
     };
   }
 
+  function computeSectionInertia(params) {
+    if (!params) {
+      return { foot: 0, tip: 0 };
+    }
+
+    const width = Number(params.b);
+    const length = Number(params.L);
+
+    function inertiaAt(x) {
+      const thicknessHere = effectiveThicknessAt(x, params);
+      if (!isFinite(width) || width <= 0) return 0;
+      if (typeof thicknessHere !== 'number' || !isFinite(thicknessHere) || thicknessHere <= 0) return 0;
+      return width * Math.pow(thicknessHere, 3) / 12.0;
+    }
+
+    const tipPosition = isFinite(length) && length > 0 ? length : 0;
+
+    return {
+      foot: inertiaAt(0),
+      tip: inertiaAt(tipPosition),
+    };
+  }
+
   function createBendingProfilePoints(profile, options) {
     if (!profile || !Array.isArray(profile.X) || !Array.isArray(profile.Y)) return [];
 
@@ -377,6 +400,7 @@
     computeBendingProfile: computeBendingProfile,
     solveForLoad: solveForLoad,
     computeLaminateStack: computeLaminateStack,
+    computeSectionInertia: computeSectionInertia,
     computeDefaultParams: computeDefaultParams,
     createBendingProfilePoints: createBendingProfilePoints,
     createBendingProfileSvg: createBendingProfileSvg,

--- a/docs/fin-bending-render.js
+++ b/docs/fin-bending-render.js
@@ -7,6 +7,7 @@
   const computeBendingProfile = core.computeBendingProfile;
   const solveForLoad = core.solveForLoad;
   const computeLaminateStack = core.computeLaminateStack;
+  const computeSectionInertia = core.computeSectionInertia;
 
   const appRoot = document.getElementById('fin-bending-app');
   if (!appRoot) {
@@ -90,6 +91,7 @@
     const load = solveForLoad(params);
     const profile = computeBendingProfile(load, params);
     const laminateStack = computeLaminateStack(params);
+    const sectionInertia = computeSectionInertia(params);
     const loadKg = load / 9.81;
     const points = core.createBendingProfilePoints(profile);
     const highlightPoint = points[profile.maxCurvatureIndex];
@@ -114,7 +116,20 @@
       laminateContainer.innerHTML = laminateSvg || '';
     }
 
-    outputEl.textContent = 'Angle at tip = ' + profile.tipAngleDeg.toFixed(1) + '°, Load at tip = ' + load.toFixed(1) + ' N (' + loadKg.toFixed(2) + ' kg)';
+    const footInertia = sectionInertia && typeof sectionInertia.foot === 'number' && isFinite(sectionInertia.foot)
+      ? sectionInertia.foot
+      : NaN;
+    const tipInertia = sectionInertia && typeof sectionInertia.tip === 'number' && isFinite(sectionInertia.tip)
+      ? sectionInertia.tip
+      : NaN;
+
+    const formattedFootInertia = isFinite(footInertia) ? footInertia.toFixed(2) + ' mm⁴' : '—';
+    const formattedTipInertia = isFinite(tipInertia) ? tipInertia.toFixed(2) + ' mm⁴' : '—';
+
+    outputEl.innerHTML =
+      'Angle at tip = ' + profile.tipAngleDeg.toFixed(1) + '°, Load at tip = ' + load.toFixed(1) + ' N (' + loadKg.toFixed(2) + ' kg)' +
+      '<br>I at foot = ' + formattedFootInertia +
+      '<br>I at tip = ' + formattedTipInertia;
   }
 
   update();

--- a/tests/approvals/cantilever-compare.payload.approved.json
+++ b/tests/approvals/cantilever-compare.payload.approved.json
@@ -9,5 +9,9 @@
   },
   "load": 23.53515625,
   "tipAngleDeg": 90.023321517,
-  "tipDeflection": 195.757839562
+  "tipDeflection": 195.757839562,
+  "sectionInertia": {
+    "foot": 14.554485,
+    "tip": 14.554485
+  }
 }

--- a/tests/approvals/default-params.payload.approved.json
+++ b/tests/approvals/default-params.payload.approved.json
@@ -9,5 +9,9 @@
   },
   "load": 23.876953125,
   "tipAngleDeg": 90.031472459,
-  "tipDeflection": 153.570955958
+  "tipDeflection": 153.570955958,
+  "sectionInertia": {
+    "foot": 41.16,
+    "tip": 5.145
+  }
 }

--- a/tests/fin-bending-core.approval.test.js
+++ b/tests/fin-bending-core.approval.test.js
@@ -48,6 +48,7 @@ describe('fin bending core approvals', () => {
       const load = core.solveForLoad(params);
       const profile = core.computeBendingProfile(load, params);
       const laminate = core.computeLaminateStack(params);
+      const inertia = core.computeSectionInertia(params);
 
       const shape = core.createBendingProfilePoints(profile);
       const highlightPoint = Array.isArray(shape) ? shape[profile.maxCurvatureIndex] : null;
@@ -60,6 +61,10 @@ describe('fin bending core approvals', () => {
         load: round(load, 9),
         tipAngleDeg: round(profile.tipAngleDeg, 9),
         tipDeflection: round(profile.tipDeflection, 9),
+        sectionInertia: {
+          foot: round(inertia.foot, 9),
+          tip: round(inertia.tip, 9),
+        },
       };
 
       let approvalError;

--- a/tests/fin-bending-core.test.js
+++ b/tests/fin-bending-core.test.js
@@ -65,3 +65,11 @@ test('createLaminateStackSvg reflects layer counts', () => {
   expect(svg).toContain('Tip');
   expect(svg).toContain('<line');
 });
+
+test('computeSectionInertia reports higher inertia at the foot when layers are thicker', () => {
+  const params = createParams();
+  const inertia = core.computeSectionInertia(params);
+
+  expect(inertia.foot).toBeGreaterThan(inertia.tip);
+  expect(inertia.tip).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- compute the fin section inertia at the foot and tip inside the core module
- include the inertia values in approval payloads and add coverage for the new helper
- render “I at foot” and “I at tip” in the calculator output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7aec4cce0832c9e1ea97b5643a781